### PR TITLE
highlight type sigs without spaces around `::`

### DIFF
--- a/syntax/haskell.vim
+++ b/syntax/haskell.vim
@@ -36,7 +36,7 @@ syn match haskellRecordField "[_a-z][a-zA-Z0-9_']*\s*::" contained
   \ haskellIdentifier,
   \ haskellOperators
 syn match haskellTypeSig
-  \ "[_a-z][a-zA-Z0-9_']*\(,\s*[_a-z][a-zA-Z0-9_']*\)*\(\s*::\|\n\s\+::\)\s"
+  \ "[_a-z][a-zA-Z0-9_']*\(,\s*[_a-z][a-zA-Z0-9_']*\)*\(\s*::\|\n\s\+::\)\s*"
   \ contains=
   \ haskellIdentifier,
   \ haskellOperators,


### PR DESCRIPTION
This is to highlight lines like:

```haskell
f::Int->Int
```