### PR TITLE
Some progress on #49

### DIFF
--- a/syntax/haskell.vim
+++ b/syntax/haskell.vim
@@ -93,7 +93,8 @@ syn region haskellImport
   \ haskellType,
   \ haskellLineComment,
   \ haskellBlockComment,
-  \ haskellDot
+  \ haskellDot,
+  \ haskellPreProc
 syn keyword haskellStatement do case of in
 syn keyword haskellWhere where
 syn keyword haskellLet let

--- a/syntax/haskell.vim
+++ b/syntax/haskell.vim
@@ -94,7 +94,8 @@ syn region haskellImport
   \ haskellLineComment,
   \ haskellBlockComment,
   \ haskellDot,
-  \ haskellPreProc
+  \ haskellPreProc,
+  \ haskellPragma
 syn keyword haskellStatement do case of in
 syn keyword haskellWhere where
 syn keyword haskellLet let


### PR DESCRIPTION
This fixes some stuff, but `$(..)` syntax is still not highlighted.

Example:

```haskell
import Blah
$(...) -- not highlighted properly
```