### PR TITLE
proper indent for block comment

### DIFF
--- a/indent/haskell.vim
+++ b/indent/haskell.vim
@@ -63,6 +63,15 @@ function! GetHaskellIndent()
     return match(l:prevline, '\S')
   endif
 
+  if synIDattr(synID(line("."), col("."), 1), "name") == 'haskellBlockComment'
+      for l:c in range(v:lnum - 1, 0, -1)
+          let l:bline = getline(l:c)
+          if l:bline =~ '{-'
+              return 1 + match(l:bline, '{-')
+      endfor
+      return 1
+  endif
+
   if l:prevline =~ '^\s*$'
       return 0
   endif


### PR DESCRIPTION
The piece of code I added is meant for block comment indentation, such that following effect can be achieved:
```
{- <cr>
 - <cr>
 - <cr>
 - -}
```

first of all, a vim session with haskell file opened should be configured properly first:
```
:set comments=s1fl:{-,mb:-,ex:-},:--
:set formatoptions+=ro
```
if the **original** setting is used, then the following will be the outcome:
```
{- <cr>
- <cr>
- <cr>
- -}
```
notice that the `-` at each line won't be aligned.

by adding my code, first vim will try to detect if the current position is in block comment. if so, vim will try to find the indent of the first occurrence of `{-` and make the `-` later the same the dash in `{-`.

for more info, please have a look at my question in stack exchange: http://vi.stackexchange.com/questions/4368/how-can-i-configure-a-three-piece-comment/4388#4388 