### PR TITLE
Character highlighting causes the whole file to be highlighted as string

### DIFF
--- a/syntax/haskell.vim
+++ b/syntax/haskell.vim
@@ -82,7 +82,7 @@ syn match haskellBacktick "`[A-Za-z_][A-Za-z0-9_\.']*`"
 syn region haskellString start=+"+ skip=+\\\\\|\\"+ end=+"+
   \ contains=@Spell
 syn match haskellIdentifier "[_a-z][a-zA-z0-9_']*" contained
-syn match haskellChar "\<'[^'\\]'\|'\\.'\|'\\u[0-9a-fA-F]\{4}'\>"
+syn match haskellChar "'[^'\\]'\|'\\.'\|'\\u[0-9a-fA-F]\{4}'"
 syn match haskellType "\<[A-Z][a-zA-Z0-9_']*\>"
 syn region haskellBlockComment start="{-" end="-}"
   \ contains=


### PR DESCRIPTION
Currently character highlighting is broken, as far as I understand there's literally no way to highlight a valid Haskell character literal as a character literal.

Most of the time this is no big deal, but if you're writing a parser/lexer code and have something like `'"'`, then current highlighter considers that as beginning of a string, and it causes the whole file to be highlighted as a string.

Attached patch fixes character highlighting, but I'm not sure if it breaks some other things.