### PR TITLE
Remove one flag from formatoptions at a time

### DIFF
--- a/after/ftplugin/cabal.vim
+++ b/after/ftplugin/cabal.vim
@@ -1,4 +1,4 @@
 setlocal comments=s1fl:{-,mb:-,ex:-},:--
-setlocal formatoptions-=cro formatoptions+=j
+setlocal formatoptions-=c formatoptions-=r formatoptions-=o formatoptions+=j
 setlocal iskeyword+=-,.,*
 setlocal commentstring=--\ %s

--- a/after/ftplugin/haskell.vim
+++ b/after/ftplugin/haskell.vim
@@ -1,3 +1,3 @@
 setlocal comments=s1fl:{-,mb:-,ex:-},:--
-setlocal formatoptions-=cro formatoptions+=j
+setlocal formatoptions-=c formatoptions-=r formatoptions-=o formatoptions+=j
 setlocal iskeyword+='


### PR DESCRIPTION
See `:help remove-option-flags`. `setlocal formatoptions-=cro` searches 'formatoptions' for exact "cro", so "c", "r", or "o" flag won't be removed if 'formatoptions' is "cor", "cr", "crto", etc.