### PR TITLE
Fix typo obstructing documentation navigation

### DIFF
--- a/doc/haskell-vim.txt
+++ b/doc/haskell-vim.txt
@@ -7,7 +7,7 @@ CONTENTS                                                   *haskell-vim-contents
 
   1. Features      |haskell-vim-features|
   2. Configuration |haskell-vim-configuration|
-  3. Highlighting  |haskell-vim-ndentation|
+  3. Highlighting  |haskell-vim-indentation|
 
 ===============================================================================
 FEATURES                                                   *haskell-vim-features*


### PR DESCRIPTION
There was a minor typo in the docs that caused navigation to be broken (for one of the links), which I then fixed. No big deal.