### PR TITLE
add haskell_disable_TH configuration variable for Template Haskell disabling 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ let g:haskell_enable_static_pointers = 1  " to enable highlighting of `static`
 `haskell-vim` has an opinionated highlighting. If you do not like that you can switch to
 a more traditional mode by setting `g:haskell_classic_highlighting` to `1`.
 
+Disabling Template Haskell and Quasiquoting syntax is possible by setting
+`g:haskell_disable_TH` to `1`.
+
 ### Indentation
 
 To configure indentation in `haskell-vim` you can use the following variables to change indentation depth, just add the according line to your `.vimrc`.

--- a/doc/haskell-vim.txt
+++ b/doc/haskell-vim.txt
@@ -39,6 +39,7 @@ the according variable to 1 in the `.vimrc`.
   * |haskell-vim-enable-typeroles|
   * |haskell-vim-enable-static-pointers|
   * |haskell-vim-classic-highlighting|
+  * |haskell-vim-disable-TH|
 
                                                *haskell-vim-enable-quantification*
 `g:haskell_enable_quantification`   Enables highlighting of `forall`.
@@ -64,6 +65,10 @@ the according variable to 1 in the `.vimrc`.
 `haskell-vim` has an opinionated highlighting. If you do not like that you can
 switch to a more traditional mode by setting `g:haskell_classic_highlighting`
 to 1.
+
+                                                *haskell-vim-disable-TH*
+Disabling Template Haskell and Quasiquoting syntax is possible by setting
+`g:haskell_disable_TH` to `1`.
 
 ===============================================================================
 INDENTATION                                             *haskell-vim-indentation*

--- a/syntax/haskell.vim
+++ b/syntax/haskell.vim
@@ -11,6 +11,10 @@ elseif exists("b:current_syntax")
   finish
 endif
 
+if !exists('g:haskell_disable_TH')
+    let g:haskell_disable_TH = 0
+endif
+
 syn spell notoplevel
 syn match haskellRecordField contained containedin=haskellBlock
   \ "[_a-z][a-zA-Z0-9_']*\(,\s*[_a-z][a-zA-Z0-9_']*\)*\(\s*::\|\n\s\+::\)"
@@ -92,14 +96,16 @@ syn region haskellBlockComment start="{-" end="-}"
   \ haskellTodo,
   \ @Spell
 syn region haskellPragma start="{-#" end="#-}"
-syn match haskellQuasiQuoted "." containedin=haskellQuasiQuote contained
-syn region haskellQuasiQuote matchgroup=haskellTH start="\[[_a-zA-Z][a-zA-z0-9._']*|" end="|\]"
-syn region haskellTHBlock matchgroup=haskellTH start="\[\(d\|t\|p\)\?|" end="|]" contains=TOP
-syn region haskellTHDoubleBlock matchgroup=haskellTH start="\[||" end="||]" contains=TOP
 syn match haskellPreProc "^#.*$"
 syn keyword haskellTodo TODO FIXME contained
 " Treat a shebang line at the start of the file as a comment
 syn match haskellShebang "\%^#!.*$"
+if exists('g:haskell_disable_TH') && g:haskell_disable_TH == 0
+    syn match haskellQuasiQuoted "." containedin=haskellQuasiQuote contained
+    syn region haskellQuasiQuote matchgroup=haskellTH start="\[[_a-zA-Z][a-zA-z0-9._']*|" end="|\]"
+    syn region haskellTHBlock matchgroup=haskellTH start="\[\(d\|t\|p\)\?|" end="|]" contains=TOP
+    syn region haskellTHDoubleBlock matchgroup=haskellTH start="\[||" end="||]" contains=TOP
+endif
 if exists('g:haskell_enable_typeroles') && g:haskell_enable_typeroles == 1
   syn keyword haskellTypeRoles phantom representational nominal contained
   syn region haskellTypeRoleBlock matchgroup=haskellTypeRoles start="type\s\+role" end="$" keepend


### PR DESCRIPTION
I found out that while writing Yesod apps the Template Haskell and QuasiQuotes syntax coloring gets flatten out like strings, and by disabling them I get nice braces and types coloring, so using:

`let g:haskell_disable_TH = 1` disables the TH syntax, which would be enabled by default.

This might be a bit subjective, so feel free to dismiss it.