### PR TITLE
Disable indentation - configuration variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ Disabling Template Haskell and Quasiquoting syntax is possible by setting
 
 To configure indentation in `haskell-vim` you can use the following variables to change indentation depth, just add the according line to your `.vimrc`.
 
-Given the current problems with indentation (being solved in the *indentation*
-branch) you can disable the indentation by setting `g:haskell_indent_disable` to
+If you dislike how indentation works you can disable it by setting `g:haskell_indent_disable` to
 `1`.
 
 Additionally you can use the

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ Disabling Template Haskell and Quasiquoting syntax is possible by setting
 
 To configure indentation in `haskell-vim` you can use the following variables to change indentation depth, just add the according line to your `.vimrc`.
 
+Given the current problems with indentation (being solved in the *indentation*
+branch) you can disable the indentation by setting `g:haskell_indent_disable` to
+`1`.
+
+Additionally you can use the
+[vim-hindent](https://github.com/alx741/vim-hindent) plugin to achieve automatic
+indentation using *hindent*.
+
 #### Haskell
 
 * `let g:haskell_indent_if = 3`

--- a/doc/haskell-vim.txt
+++ b/doc/haskell-vim.txt
@@ -76,6 +76,8 @@ INDENTATION                                             *haskell-vim-indentation
 To configure indentation in `haskell-vim` you can use the following variables to
 change indentation depth, just add the according line to your `.vimrc`.
 
+You can disable the indentation by setting `g:haskell_indent_disable` to `1`.
+
 Haskell~
 
   * |haskell-vim-indent-if|

--- a/indent/haskell.vim
+++ b/indent/haskell.vim
@@ -13,6 +13,10 @@ endif
 
 let b:did_indent = 1
 
+if !exists('g:haskell_indent_disable')
+    let g:haskell_indent_disable = 0
+endif
+
 if !exists('g:haskell_indent_if')
   " if x
   " >>>then ...
@@ -57,8 +61,14 @@ if !exists('g:haskell_indent_guard')
   let g:haskell_indent_guard = 2
 endif
 
-setlocal indentexpr=GetHaskellIndent()
-setlocal indentkeys=0{,0},0(,0),0[,0],!^F,o,O,0\=,0=where,0=let,0=deriving,<space>
+if exists("g:haskell_indent_disable") && g:haskell_indent_disable == 0
+    setlocal indentexpr=GetHaskellIndent()
+    setlocal indentkeys=0{,0},0(,0),0[,0],!^F,o,O,0\=,0=where,0=let,0=deriving,<space>
+else
+    setlocal nocindent
+    setlocal nosmartindent
+    setlocal autoindent
+endif
 
 function! s:isInBlock(hlstack)
   return index(a:hlstack, 'haskellParens') > -1 || index(a:hlstack, 'haskellBrackets') > -1 || index(a:hlstack, 'haskellBlock') > -1 || index(a:hlstack, 'haskellBlockComment') > -1 || index(a:hlstack, 'haskellPragma') > -1


### PR DESCRIPTION
Currently there are a lot of issues with the indentation that make it unusable, it forces indentation in such a way that the resulting code won't compile, and it's a bit of a PITA [#85 #83 #82 #73 #75 #69].

So the `g:haskell_indent_disable` can be set to `1` (it defaults to `0`) can be used to disable the indentation in a graceful way until these problems (or most of them at least) are solved in the *indentation* branch. It sets `autoindent` so the user benefits from the same-level-indentation magic but still has the control over the right indentation to use at any time.

Additionally, *hindent* can be used for the `equalprg` setting, so using `=` will work as expected and don't mess up all the indentation. But this is not recommended as *hindent* will replace the code with an error message if it happens to be a syntax error on it. So the *vim-hindent* plugin is suggested to handle that issue and give auto indentation and formatting on file save.

I'm currently trying this commit with my own code, and it's quite an enormous relief having the indentation to behave.