### PR TITLE
Disabling Indent should ignore entire indent file

### DIFF
--- a/indent/haskell.vim
+++ b/indent/haskell.vim
@@ -11,11 +11,15 @@ if exists('b:did_indent')
   finish
 endif
 
-let b:did_indent = 1
-
 if !exists('g:haskell_indent_disable')
     let g:haskell_indent_disable = 0
 endif
+
+if g:haskell_indent_disable != 0
+  finish
+endif
+
+let b:did_indent = 1
 
 if !exists('g:haskell_indent_if')
   " if x
@@ -61,14 +65,8 @@ if !exists('g:haskell_indent_guard')
   let g:haskell_indent_guard = 2
 endif
 
-if exists("g:haskell_indent_disable") && g:haskell_indent_disable == 0
-    setlocal indentexpr=GetHaskellIndent()
-    setlocal indentkeys=0{,0},0(,0),0[,0],!^F,o,O,0\=,0=where,0=let,0=deriving,<space>
-else
-    setlocal nocindent
-    setlocal nosmartindent
-    setlocal autoindent
-endif
+setlocal indentexpr=GetHaskellIndent()
+setlocal indentkeys=0{,0},0(,0),0[,0],!^F,o,O,0\=,0=where,0=let,0=deriving,<space>
 
 function! s:isInBlock(hlstack)
   return index(a:hlstack, 'haskellDelimiter') > -1 || index(a:hlstack, 'haskellParens') > -1 || index(a:hlstack, 'haskellBrackets') > -1 || index(a:hlstack, 'haskellBlock') > -1 || index(a:hlstack, 'haskellBlockComment') > -1 || index(a:hlstack, 'haskellPragma') > -1


### PR DESCRIPTION
Pull Request for Issue #90 

## Description

Setting `g:haskell_indent_disable = 1` should force `haskell-vim` to ignore entirety of `intent/haskell.vim`, and not set `b:did_indent`, thus allowing a different plugin to provide indentation.

## Solution

Before setting `b:did_indent = 1` we first check whether or not `g:haskell_indent_disable` flag has been set to a non-zero value.  If it has, we `finish` and do nothing.

I also took the liberty of cleaning up some otherwise dead code.  Now that we utilize `g:haskell_indent_disable` as an exit condition, the else section of the if statement is (provably) never executed.  Thus, there is no reason for it to exist.

The "default" within the else are omitted, as I would think that if we were to want to ignore the indentation file, we don't want to assume anything about what settings the user actually wants, and trust them to make their own decisions.

## Testing

I tested this change by doing the following:

1. Copy my currently installed `indent/haskell.vim` within neovim config to `indent/haskell.vim.bak`
2. Copy this new `indent/haskell.vim` from my repository into my neovim config files.
3. Start and test indentation for neovim in the following scenarios:
    * Haskell-vim with indent enabled, then vim indent plugin - Haskell Vim intent utilized
    * Haskell-vim with indent disabled, then vim indent plugin - Indent plugin utilized
    * vim indent plugin, then haskell-vim with indent enabled - indent plugin utilized
    * vim indent plugin, then haskell-vim with indent disabled - indent plugin utilized