### PR TITLE
Support of 2+2 space indentation of where

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ indentation using *hindent*.
         where f :: Int -> Int
         >>>>>>f x = x
 
+* `let g:haskell_indent_before_where = 2`
+
+        foo
+        >>where
+
+* `let g:haskell_indent_after_bare_where = 2`
+
+        where
+        >>foo
+
 * `let g:haskell_indent_do = 3`
 
         do x <- a

--- a/doc/haskell-vim.txt
+++ b/doc/haskell-vim.txt
@@ -84,6 +84,8 @@ Haskell~
   * |haskell-vim-indent-case|
   * |haskell-vim-indent-let|
   * |haskell-vim-indent-where|
+  * |haskell-vim-indent-before-where|
+  * |haskell-vim-indent-after-bare-where|
   * |haskell-vim-indent-do|
   * |haskell-vim-indent-in|
   * |haskell-vim-indent-guard|
@@ -113,6 +115,18 @@ Haskell~
 
         where f :: Int -> Int
         >>>>>>f x = x
+<
+                                                 *haskell-vim-indent-before-where*
+* let g:haskell_indent_before_where = 2 >
+
+        foo
+        >>where
+<
+                                             *haskell-vim-indent-after-bare-where*
+* let g:haskell_indent_after_bare_where = 2 >
+
+        where
+        >>foo
 <
                                                            *haskell-vim-indent-do*
 * let g:haskell_indent_do = 3 >

--- a/indent/haskell.vim
+++ b/indent/haskell.vim
@@ -37,10 +37,22 @@ if !exists('g:haskell_indent_let')
   let g:haskell_indent_let = 4
 endif
 
+if !exists('g:haskell_indent_before_where')
+  " f x = g
+  " >>where
+  let g:haskell_indent_before_where = &shiftwidth
+endif
+
 if !exists('g:haskell_indent_where')
   " where f :: Int -> Int
   " >>>>>>f x = x
   let g:haskell_indent_where = 6
+endif
+
+if !exists('g:haskell_indent_after_bare_where')
+  " where
+  " >>g y = x y
+  let g:haskell_indent_after_bare_where = &shiftwidth
 endif
 
 if !exists('g:haskell_indent_do')
@@ -243,12 +255,16 @@ function! GetHaskellIndent()
   " where
   " >>foo
   "
+  if l:prevline =~ '\C\<where\>\s*$'
+    return match(l:prevline, '\S') + g:haskell_indent_after_bare_where
+  endif
+
   " do
   " >>foo
   "
   " foo =
   " >>bar
-  if l:prevline =~ '\C\(\<where\>\|\<do\>\|=\)\s*$'
+  if l:prevline =~ '\C\(\<do\>\|=\)\s*$'
     return match(l:prevline, '\S') + &shiftwidth
   endif
 
@@ -405,7 +421,7 @@ function! GetHaskellIndent()
       return match(l:prevline, 'in') - g:haskell_indent_in
     endif
 
-    return match(l:prevline, '\S') + &shiftwidth
+    return match(l:prevline, '\S') + g:haskell_indent_before_where
   endif
 
   " let x = 1

--- a/indent/haskell.vim
+++ b/indent/haskell.vim
@@ -37,22 +37,10 @@ if !exists('g:haskell_indent_let')
   let g:haskell_indent_let = 4
 endif
 
-if !exists('g:haskell_indent_before_where')
-  " f x = g
-  " >>where
-  let g:haskell_indent_before_where = &shiftwidth
-endif
-
 if !exists('g:haskell_indent_where')
   " where f :: Int -> Int
   " >>>>>>f x = x
   let g:haskell_indent_where = 6
-endif
-
-if !exists('g:haskell_indent_after_bare_where')
-  " where
-  " >>g y = x y
-  let g:haskell_indent_after_bare_where = &shiftwidth
 endif
 
 if !exists('g:haskell_indent_do')
@@ -256,7 +244,7 @@ function! GetHaskellIndent()
   " >>foo
   "
   if l:prevline =~ '\C\<where\>\s*$'
-    return match(l:prevline, '\S') + g:haskell_indent_after_bare_where
+    return match(l:prevline, '\S') + get(g:, 'haskell_indent_after_bare_where', &shiftwidth)
   endif
 
   " do
@@ -416,12 +404,17 @@ function! GetHaskellIndent()
 
   "  in foo
   " where bar
+  "
+  " or
+  "
+  " foo
+  " >>where
   if l:line =~ '\C^\s*\<where\>'
     if match(l:prevline, '\C^\s\+in\s\+') == 0
       return match(l:prevline, 'in') - g:haskell_indent_in
     endif
 
-    return match(l:prevline, '\S') + g:haskell_indent_before_where
+    return match(l:prevline, '\S') + get(g:, 'haskell_indent_before_where', &shiftwidth)
   endif
 
   " let x = 1

--- a/tests/indent/test015/expected.hs
+++ b/tests/indent/test015/expected.hs
@@ -1,0 +1,3 @@
+f x = y
+  where
+    y = 2 * x

--- a/tests/indent/test015/test.hs
+++ b/tests/indent/test015/test.hs
@@ -1,0 +1,3 @@
+f x = y
+where
+y = 2 * x

--- a/tests/indent/test015/test.vim
+++ b/tests/indent/test015/test.vim
@@ -1,0 +1,6 @@
+:set sw=4
+:let g:haskell_indent_before_where=2
+:let g:haskell_indent_after_bare_where=2
+=G
+:saveas! result.hs
+:q!


### PR DESCRIPTION
I saw that the indentation of  `where` often came up in the issues, including difficulties indenting it with 2 spaces (while using 4 otherwise):

```
foo x = bar
  where
    bar = x + 2
```

I see that it's not feasible to get the indentation right all they time, but I added two configuration parameters for this use case:
- `haskell_indent_where_pre` allows to determine how far a `where` should be indented (unless after an `in`, I did not want to change this behavior)
- `haskell_indent_where_bare` allows to determine the indentation of the line after a bare `where` (newline directly after it).

The names could be improved... maybe `_before_where` and `bare_where`?

I hope this does not break other use cases, but it seems to be fine and both options default to the previous behavior, the changes are completely opt-in. Personally, I set them to 2.
If you want to pull this, I can add documentation as well.
