### PR TITLE
Add option g:haskell_indent_let_no_in

### DIFF
--- a/indent/haskell.vim
+++ b/indent/haskell.vim
@@ -34,7 +34,16 @@ endif
 if !exists('g:haskell_indent_let')
   " let x = 0 in
   " >>>>x
+  "
+  " let x = 0
+  "     y = 1
   let g:haskell_indent_let = 4
+endif
+
+if !exists('g:haskell_indent_let_no_in')
+  " let x = 0
+  "     x
+  let g:haskell_indent_let_no_in = 4
 endif
 
 if !exists('g:haskell_indent_where')
@@ -208,6 +217,9 @@ function! GetHaskellIndent()
   "
   " let x = 1
   " >>>>y = 2
+  "
+  " let x = 1
+  " y 2
   if l:prevline =~ '\C\<let\>\s\+.\+$'
     if l:line =~ '\C^\s*\<let\>'
       let l:s = match(l:prevline, '\C\<let\>')
@@ -219,10 +231,15 @@ function! GetHaskellIndent()
       if s:isSYN('haskellLet', v:lnum - 1, l:s + 1)
         return l:s + g:haskell_indent_in
       endif
-    else
+    elseif l:line =~ '\s=\s'
       let l:s = match(l:prevline, '\C\<let\>')
       if s:isSYN('haskellLet', v:lnum - 1, l:s + 1)
         return l:s + g:haskell_indent_let
+      endif
+    else
+      let l:s = match(l:prevline, '\C\<let\>')
+      if s:isSYN('haskellLet', v:lnum - 1, l:s + 1)
+        return l:s + g:haskell_indent_let_no_in
       endif
     endif
   endif


### PR DESCRIPTION
This addresses some of the grievances in #85. Namely, we give users the
option to change how indentation works with `let` statements.

**Current behavior**:

```haskell
-- g:haskell_indent_let
let x = 0
>>>>y = 0

let x = 0 in
>>>>x

-- g:haskell_indent_in
let x = 0
>in x

-- ??? (conflated with g:haskell_indent_let)
let x = 0
>>>>x
```

**New behavior**:

```haskell
-- g:haskell_indent_no_in
let x = 0
>>>>x
```

So for example, those who omit the 'in' on the first line and any 'let'
on the second line can opt to have no indentaton:

```haskell
--- g:haskell_indent_no_in = 0
let x = 0
fooBar x
```

Thanks for this project! I really enjoy the new syntax highlighting in
particular. Also, I'm open to suggestions; let me know if you can think of
cases I haven't thought of.