### PR TITLE
align | with = in data declaration

### DIFF
--- a/indent/haskell.vim
+++ b/indent/haskell.vim
@@ -469,8 +469,12 @@ function! GetHaskellIndent()
   "
   " data Foo = Bar
   " >>>>>>>>>|
+  "
+  " data Foo
+  "     = Bar
+  " >>>>|
   if l:line =~ '^\s*|\s'
-    if l:prevline =~ '\C^\s*\<data\>.\+=.\+$'
+    if l:prevline =~ '\C^\(\s*\<data\>.\+=.\+\|\s*=\s\+.\+\)$'
       return match(l:prevline, '=')
     else
       let l:s = s:indentGuard(match(l:line, '|'), l:prevline)


### PR DESCRIPTION
issue fixed: when &shiftwidth /= g:haskell_indent_guard, say
&shiftwidth=4 and g:haskell_indent_guard=2, press enter after
the "Bar" in

    data Foo
        = Bar

and type "| Baz" will result

    data Foo
        = Bar
      | Baz

which is not we want, this commit fixes this, type "| Baz" after
"Bar" will now result

    data Foo
        = Bar
        | Baz