### PR TITLE
Highlight numbers that have underscores

### DIFF
--- a/syntax/haskell.vim
+++ b/syntax/haskell.vim
@@ -63,8 +63,8 @@ if get(g:, 'haskell_enable_static_pointers', 0)
   syn keyword haskellStatic static
 endif
 syn keyword haskellConditional if then else
-syn match haskellNumber "\<[0-9]\+\>\|\<0[xX][0-9a-fA-F]\+\>\|\<0[oO][0-7]\+\>\|\<0[bB][10]\+\>"
-syn match haskellFloat "\<[0-9]\+\.[0-9]\+\([eE][-+]\=[0-9]\+\)\=\>"
+syn match haskellNumber "\<[0-9]\+\>\|\<[0-9_]\+\>\|\<0[xX][0-9a-fA-F_]\+\>\|\<0[oO][0-7_]\+\>\|\<0[bB][10_]\+\>"
+syn match haskellFloat "\<[0-9]\+\.[0-9_]\+\([eE][-+]\=[0-9_]\+\)\=\>"
 syn match haskellSeparator  "[,;]"
 syn region haskellParens matchgroup=haskellDelimiter start="(" end=")" contains=TOP,haskellTypeSig,@Spell
 syn region haskellBrackets matchgroup=haskellDelimiter start="\[" end="]" contains=TOP,haskellTypeSig,@Spell


### PR DESCRIPTION
With `LANGUAGE NumericUnderscores` it's now possible to use `_` in numbers, e.g., `10_000`, see https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0009-numeric-underscores.rst

This adds a very simple highlighting support for this, but it's not as strict as the spec and does allow some invalid cases to be highlighted -- let me know if you'd prefer this to be stricter.