### PR TITLE
Use shiftwidth() to shift by tabstop when shiftwidth=0

### DIFF
--- a/indent/haskell.vim
+++ b/indent/haskell.vim
@@ -189,13 +189,13 @@ function! GetHaskellIndent()
 
   " operator at end of previous line
   if l:prevline =~ '[!#$%&*+./<>?@\\^|~-]\s*$'
-    return indent(v:lnum - 1) + &shiftwidth
+    return indent(v:lnum - 1) + shiftwidth()
   endif
 
   " let foo =
   " >>>>>>bar
   if l:prevline =~ '\C\<let\>\s\+[^=]\+=\s*$'
-    return match(l:prevline, '\C\<let\>') + g:haskell_indent_let + &shiftwidth
+    return match(l:prevline, '\C\<let\>') + g:haskell_indent_let + shiftwidth()
   endif
 
   " let x = 1 in
@@ -243,7 +243,7 @@ function! GetHaskellIndent()
   " >>foo
   "
   if l:prevline =~ '\C\<where\>\s*$'
-    return indent(v:lnum - 1) + get(g:, 'haskell_indent_after_bare_where', &shiftwidth)
+    return indent(v:lnum - 1) + get(g:, 'haskell_indent_after_bare_where', shiftwidth())
   endif
 
   " do
@@ -252,7 +252,7 @@ function! GetHaskellIndent()
   " foo =
   " >>bar
   if l:prevline =~ '\C\(\<do\>\|=\)\s*$'
-    return indent(v:lnum - 1) + &shiftwidth
+    return indent(v:lnum - 1) + shiftwidth()
   endif
 
   " do foo
@@ -268,7 +268,7 @@ function! GetHaskellIndent()
   " >>bar -> quux
   if l:prevline =~ '\C\<case\>.\+\<of\>\s*$'
     if get(g:,'haskell_indent_case_alternative', 0)
-      return indent(v:lnum - 1) + &shiftwidth
+      return indent(v:lnum - 1) + shiftwidth()
     else
       return match(l:prevline, '\C\<case\>') + g:haskell_indent_case
     endif
@@ -301,7 +301,7 @@ function! GetHaskellIndent()
   " newtype Foo = Foo
   " >>deriving
   if l:prevline =~ '\C^\s*\<\(newtype\|data\)\>[^{]\+' && l:line =~ '\C^\s*\<deriving\>'
-    return indent(v:lnum - 1) + &shiftwidth
+    return indent(v:lnum - 1) + shiftwidth()
   endif
 
   " foo :: Int
@@ -314,7 +314,7 @@ function! GetHaskellIndent()
     if l:line =~ '^\s*[-=]>'
       return match(l:prevline, '::\s')
     elseif match(l:prevline, '^\s\+::') > -1
-      return match(l:prevline, '::\s') - &shiftwidth
+      return match(l:prevline, '::\s') - shiftwidth()
     endif
   endif
 
@@ -394,13 +394,13 @@ function! GetHaskellIndent()
   ">>>>>=> Int
   if l:prevline =~ '^\s*)' && l:line =~ '^\s*=>'
     let l:s = match(l:prevline, ')')
-    return l:s - (&shiftwidth + 1)
+    return l:s - (shiftwidth() + 1)
   endif
 
   " module Foo
   " >>( bar
   if l:prevline =~ '\C^\<module\>'
-    return &shiftwidth
+    return shiftwidth()
   endif
 
   " foo
@@ -408,7 +408,7 @@ function! GetHaskellIndent()
   if l:line =~ '^\s*{'
     let l:s = indent(v:lnum - 1)
     if l:s >= 0
-      return l:s + &shiftwidth
+      return l:s + shiftwidth()
     endif
   endif
 
@@ -424,7 +424,7 @@ function! GetHaskellIndent()
       return match(l:prevline, 'in') - g:haskell_indent_in
     endif
 
-    return indent(v:lnum - 1) + get(g:, 'haskell_indent_before_where', &shiftwidth)
+    return indent(v:lnum - 1) + get(g:, 'haskell_indent_before_where', shiftwidth())
   endif
 
   " let x = 1
@@ -458,13 +458,13 @@ function! GetHaskellIndent()
   " >>=
   if l:line =~ '^\s*='
     if l:prevline =~ '\C^\<data\>\s\+[^=]\+\s*$'
-      return match(l:prevline, '\C\<data\>') + &shiftwidth
+      return match(l:prevline, '\C\<data\>') + shiftwidth()
     else
       let l:s = s:indentGuard(match(l:line, '='), l:prevline)
       if l:s > 0
         return l:s
       else
-        return &shiftwidth
+        return shiftwidth()
       endif
     endif
   endif
@@ -489,7 +489,7 @@ function! GetHaskellIndent()
   " foo
   " >>:: Int
   if l:line =~ '^\s*::\s'
-    return indent(v:lnum - 1) + &shiftwidth
+    return indent(v:lnum - 1) + shiftwidth()
   endif
 
   " indent closing brace, paren or bracket


### PR DESCRIPTION
Setting shiftwidth=0 means "use whatever tabstop is", and this is built-into the shiftwidth() function.

shiftwidth() the function "was introduced with patch 7.3.694 in 2012;
everybody should have it by now," says the vim documentation.