### PR TITLE
Very minor typo fix

### DIFF
--- a/syntax/haskell.vim
+++ b/syntax/haskell.vim
@@ -90,7 +90,7 @@ syn match haskellLineComment "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$"
 syn match haskellBacktick "`[A-Za-z_][A-Za-z0-9_\.']*#\?`"
 syn region haskellString start=+"+ skip=+\\\\\|\\"+ end=+"+
   \ contains=@Spell
-syn match haskellIdentifier "[_a-z][a-zA-z0-9_']*" contained
+syn match haskellIdentifier "[_a-z][a-zA-Z0-9_']*" contained
 syn match haskellChar "\<'[^'\\]'\|'\\.'\|'\\u[0-9a-fA-F]\{4}'\>"
 syn match haskellType "\<[A-Z][a-zA-Z0-9_']*\>"
 syn region haskellBlockComment start="{-" end="-}"
@@ -106,7 +106,7 @@ syn keyword haskellTodo TODO FIXME contained
 syn match haskellShebang "\%^#!.*$"
 if !get(g:, 'haskell_disable_TH', 0)
     syn match haskellQuasiQuoted "." containedin=haskellQuasiQuote contained
-    syn region haskellQuasiQuote matchgroup=haskellTH start="\[[_a-zA-Z][a-zA-z0-9._']*|" end="|\]"
+    syn region haskellQuasiQuote matchgroup=haskellTH start="\[[_a-zA-Z][a-zA-Z0-9._']*|" end="|\]"
     syn region haskellTHBlock matchgroup=haskellTH start="\[\(d\|t\|p\)\?|" end="|]" contains=TOP
     syn region haskellTHDoubleBlock matchgroup=haskellTH start="\[||" end="||]" contains=TOP
 endif


### PR DESCRIPTION
I'm pretty sure that those were supposed to be capital Z's, otherwise why would `[a-z]` and `_` be added separately?