### PR TITLE
foreign declarations may have line breaks after double-colon separator

### DIFF
--- a/syntax/haskell.vim
+++ b/syntax/haskell.vim
@@ -47,7 +47,7 @@ syn match haskellDecl "\<\(type\|data\)\>\s\+\(\<family\>\)\?"
 syn keyword haskellDefault default
 syn keyword haskellImportKeywords import qualified safe as hiding contained
 syn keyword haskellForeignKeywords foreign export import ccall safe unsafe interruptible capi prim contained
-syn region haskellForeignImport start="\<foreign\>" end="\_s\+::\s" keepend
+syn region haskellForeignImport start="\<foreign\>" end="\_s\+::\_s" keepend
   \ contains=
   \ haskellString,
   \ haskellOperators,


### PR DESCRIPTION
notice that record fields and regular type signatures are already fine (in definitions of  `haskellRecordField` and `haskellTypeSig`),

before the fix I'm getting

![haskell-vim-before-fix](https://user-images.githubusercontent.com/1219667/125323074-14700180-e347-11eb-9d1e-50ee14663b9f.png)

after the fix it gets correctly highlighted

![haskell-vim-after-fix](https://user-images.githubusercontent.com/1219667/125323211-36698400-e347-11eb-8e2d-d92bb698bbc9.png)