### PR TITLE
README: Add a link to a fork with Unicode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ own based on [idris-vim][].
 
 I hope you find this useful.
 
+N.B. If you are looking for `UnicodeSyntax` language extension support
+take a look at a fork of this plugin: [haskell-with-unicode.vim][]
+
 ![Screenshot](http://raichoo.github.io/images/haskell-vim.png)
 
 ## Features
@@ -140,3 +143,4 @@ indentation using *hindent*.
 
 [Pathogen]: https://github.com/tpope/vim-pathogen
 [idris-vim]: https://github.com/idris-hackers/idris-vim
+[haskell-with-unicode.vim]: https://github.com/wenzel-hoffman/haskell-with-unicode.vim


### PR DESCRIPTION
It would be useful for the people who want this but didn’t realize there already is an implementation they can use and not spend time implementing it themselves.

For the context you can follow these:

* https://github.com/neovimhaskell/haskell-vim/pull/106
* https://github.com/neovimhaskell/haskell-vim/pull/134
* https://github.com/neovimhaskell/haskell-vim/issues/41
* https://github.com/neovimhaskell/haskell-vim/issues/108

Also ping @Achierius, @DeCentN2Madness, and @mkohlhaas. You might find this fork useful.